### PR TITLE
Automatically detect API region for each camera

### DIFF
--- a/src/foggycam.py
+++ b/src/foggycam.py
@@ -290,7 +290,7 @@ class FoggyCam(object):
 
         self.nest_camera_buffer_threshold = config.threshold
 
-        for camera in self.nest_camera_array:            
+        for camera in self.nest_camera_array:
             camera_path = ''
             video_path = ''
 


### PR DESCRIPTION
This PR resolves [dend#25](https://github.com/dend/foggycam/issues/25)

In my home setup, I've got a number of nest devices that utilise different API urls, so hardcoding a URL did not work. My IQ for example uses US1, and my standard Nest Cam Indoors use EU1.

This change automatically detects the API endpoint for each camera as they are identified, and collects images accordingly.