### PR TITLE
Added a timestamp feature which uses imagemagick to apply date/time overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ On macOS, you can install `ffmpeg` through [Homebrew](https://brew.sh):
 brew install ffmpeg
 ```
 
+For timestamp functionality you'll need `imagemagick`:
+
+```
+sudo apt-get install imagemagick
+```
+
+On macOS, you can install `imagemagick` through Homebrew as well:
+
+```
+brew install imagemagick
+```
 ## How To Start
 
 Make sure you install the requirements for the project, by `cd`-ing in the folder with the project, and running:

--- a/src/foggycam.py
+++ b/src/foggycam.py
@@ -14,6 +14,7 @@ import threading
 import time
 from datetime import datetime
 import subprocess
+from subprocess import call
 from azurestorageprovider import AzureStorageProvider
 import shutil
 
@@ -330,6 +331,11 @@ class FoggyCam(object):
                 with open(camera_path + '/' + file_id + '.jpg', 'wb') as image_file:
                     for chunk in response:
                         image_file.write(chunk)
+
+                #Add overlay text
+                now = datetime.now()
+                overlay_text = "/usr/bin/convert " + camera_path + '/' + file_id + '.jpg' + " -pointsize 36 -fill white -stroke black -annotate +40+40 '" + now.strftime("%Y-%m-%d %H:%M:%S") + "' " + camera_path + '/' + file_id + '.jpg'
+                call ([overlay_text], shell=True)
 
                 # Check if we need to compile a video
                 if config.produce_video:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,2 @@
 azure-storage-blob==0.37.1
 pytest
-imagemagick

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 azure-storage-blob==0.37.1
 pytest
+imagemagick


### PR DESCRIPTION
…on each image generated prior to video being generated. The current functionality simply reads the system time datetime.now() function and applies it as text 40x40 from the top left (this is because some Nest cameras are widescreen and some 4:3 so it's more consistent to keep it on top). Haven't fully tested this, but it's working with my 3 cameras... also for some reason imagemagick doesn't work if you're using rc.local to run FoggyCam on boot.